### PR TITLE
Fix invisible visibility and security and security dropdowns

### DIFF
--- a/TGControlPanel/ServerPage.cs
+++ b/TGControlPanel/ServerPage.cs
@@ -130,6 +130,9 @@ namespace TGControlPanel
 			if (!ServerPathTextbox.Focused)
 				ServerPathTextbox.Text = Config.ServerDirectory();
 
+			VisibilitySelector.SelectedIndex = (int)DD.VisibilityLevel();
+			SecuritySelector.SelectedIndex = (int)DD.SecurityLevel();
+
 			if (!RepoExists)
 			{
 				updatingFields = false;
@@ -141,9 +144,6 @@ namespace TGControlPanel
 				PortSelector.Value = DD.Port();
 			if (!projectNameText.Focused)
 				projectNameText.Text = DM.ProjectName();
-
-			VisibilitySelector.SelectedIndex = (int)DD.VisibilityLevel();
-			SecuritySelector.SelectedIndex = (int)DD.SecurityLevel();
 
 			var val = Config.InteropPort(out string error);
 			if (error != null)


### PR DESCRIPTION
These would be invisible if the repo didn't exist due to being checked after verifying that it did exist