### PR TITLE
Fixes App.Config bug

### DIFF
--- a/TGServerService/App.config
+++ b/TGServerService/App.config
@@ -72,44 +72,6 @@
                 <value>John Madden</value>
             </setting>
         </TGServerService.Properties.Settings>
-        <ServerService.Properties.Settings>
-            <setting name="RepoURL" serializeAs="String">
-                <value>https://github.com/tgstation/tgstation.git</value>
-            </setting>
-            <setting name="ProjectName" serializeAs="String">
-                <value>tgstation</value>
-            </setting>
-            <setting name="ServerPort" serializeAs="String">
-                <value>2337</value>
-            </setting>
-            <setting name="RepoBranch" serializeAs="String">
-                <value>master</value>
-            </setting>
-            <setting name="PushChangelogToGit" serializeAs="String">
-                <value>False</value>
-            </setting>
-            <setting name="ByondPath" serializeAs="String">
-                <value>C:\Program Files (x86)\BYOND\bin</value>
-            </setting>
-            <setting name="CommitterName" serializeAs="String">
-                <value>tgstation-server</value>
-            </setting>
-            <setting name="CommitterEmail" serializeAs="String">
-                <value>tgstation-server@users.noreply.github.com</value>
-            </setting>
-            <setting name="CredentialUsername" serializeAs="String">
-                <value>tgstation-server</value>
-            </setting>
-            <setting name="CredentialEntropy" serializeAs="String">
-                <value>Insufficient data for meaningful answer</value>
-            </setting>
-            <setting name="CredentialCyphertext" serializeAs="String">
-                <value>hunter2</value>
-            </setting>
-            <setting name="WCFPort" serializeAs="String">
-                <value>8000</value>
-            </setting>
-        </ServerService.Properties.Settings>
     </userSettings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
This prevented the service from starting because it was trying to reference a namespace that didn't exist