### PR TITLE
v6.19.1: Fix git interaction with GitHub app auth

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -3,7 +3,7 @@
   <!-- Integration tests will ensure they match across the board -->
   <Import Project="WebpanelVersion.props" />
   <PropertyGroup>
-    <TgsCoreVersion>6.19.0</TgsCoreVersion>
+    <TgsCoreVersion>6.19.1</TgsCoreVersion>
     <TgsConfigVersion>5.9.0</TgsConfigVersion>
     <TgsRestVersion>10.14.0</TgsRestVersion>
     <TgsGraphQLVersion>0.7.0</TgsGraphQLVersion>

--- a/src/Tgstation.Server.Host/Components/Repository/DefaultGitRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/DefaultGitRemoteFeatures.cs
@@ -31,5 +31,9 @@ namespace Tgstation.Server.Host.Components.Repository
 			TestMergeParameters parameters,
 			RepositorySettings repositorySettings,
 			CancellationToken cancellationToken) => throw new NotSupportedException();
+
+		/// <inheritdoc />
+		public ValueTask<string?> TransformRepositoryPassword(string? rawPassword, CancellationToken cancellationToken)
+			=> ValueTask.FromResult(rawPassword);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Repository/GitHubRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitHubRemoteFeatures.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Microsoft.Extensions.Logging;
+
 using Octokit;
 
 using Tgstation.Server.Api.Models;
@@ -39,6 +40,19 @@ namespace Tgstation.Server.Host.Components.Repository
 			: base(logger, remoteUrl)
 		{
 			this.gitHubServiceFactory = gitHubServiceFactory ?? throw new ArgumentNullException(nameof(gitHubServiceFactory));
+		}
+
+		/// <inheritdoc />
+		public override async ValueTask<string?> TransformRepositoryPassword(string? rawPassword, CancellationToken cancellationToken)
+		{
+			if (rawPassword == null)
+				return null;
+
+			var gitHubService = await gitHubServiceFactory.CreateService(
+				rawPassword,
+				new RepositoryIdentifier(this),
+				cancellationToken);
+			return gitHubService?.GetGitPassword() ?? rawPassword;
 		}
 
 		/// <inheritdoc />

--- a/src/Tgstation.Server.Host/Components/Repository/GitLabRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitLabRemoteFeatures.cs
@@ -43,6 +43,10 @@ namespace Tgstation.Server.Host.Components.Repository
 		}
 
 		/// <inheritdoc />
+		public override ValueTask<string?> TransformRepositoryPassword(string? rawPassword, CancellationToken cancellationToken)
+			=> ValueTask.FromResult(rawPassword);
+
+		/// <inheritdoc />
 		protected override async ValueTask<Models.TestMerge> GetTestMergeImpl(
 			TestMergeParameters parameters,
 			RepositorySettings repositorySettings,

--- a/src/Tgstation.Server.Host/Components/Repository/GitRemoteFeaturesBase.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/GitRemoteFeaturesBase.cs
@@ -83,6 +83,9 @@ namespace Tgstation.Server.Host.Components.Repository
 			return result;
 		}
 
+		/// <inheritdoc />
+		public abstract ValueTask<string?> TransformRepositoryPassword(string? rawPassword, CancellationToken cancellationToken);
+
 		/// <summary>
 		/// Implementation of <see cref="GetTestMerge(TestMergeParameters, RepositorySettings, CancellationToken)"/>.
 		/// </summary>

--- a/src/Tgstation.Server.Host/Components/Repository/ICredentialsProvider.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/ICredentialsProvider.cs
@@ -1,4 +1,7 @@
-﻿using LibGit2Sharp;
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 
 using Tgstation.Server.Host.Jobs;
@@ -13,10 +16,12 @@ namespace Tgstation.Server.Host.Components.Repository
 		/// <summary>
 		/// Generate a <see cref="CredentialsHandler"/> from a given <paramref name="username"/> and <paramref name="password"/>.
 		/// </summary>
+		/// <param name="remoteFeatures">The <see cref="IGitRemoteFeatures"/> for the repository in question.</param>
 		/// <param name="username">The optional username to use in the <see cref="CredentialsHandler"/>.</param>
 		/// <param name="password">The optional password to use in the <see cref="CredentialsHandler"/>.</param>
-		/// <returns>A new <see cref="CredentialsHandler"/>.</returns>
-		CredentialsHandler GenerateCredentialsHandler(string? username, string? password);
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in a new <see cref="CredentialsHandler"/>.</returns>
+		ValueTask<CredentialsHandler> GenerateCredentialsHandler(IGitRemoteFeatures remoteFeatures, string? username, string? password, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// Rethrow the authentication failure message as a <see cref="JobException"/> if it is one.

--- a/src/Tgstation.Server.Host/Components/Repository/IGitRemoteFeatures.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/IGitRemoteFeatures.cs
@@ -1,4 +1,7 @@
-﻿namespace Tgstation.Server.Host.Components.Repository
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tgstation.Server.Host.Components.Repository
 {
 	/// <summary>
 	/// Provides features for remote git services.
@@ -14,5 +17,13 @@
 		/// Get.
 		/// </summary>
 		string TestMergeLocalBranchNameFormatter { get; }
+
+		/// <summary>
+		/// Transform a service's <paramref name="rawPassword"/> into a password usable by git.
+		/// </summary>
+		/// <param name="rawPassword">The raw password to transform.</param>
+		/// <param name="cancellationToken">The <see cref="CancellationToken"/> for the operation.</param>
+		/// <returns>A <see cref="ValueTask{TResult}"/> resulting in the transformed password.</returns>
+		public ValueTask<string?> TransformRepositoryPassword(string? rawPassword, CancellationToken cancellationToken);
 	}
 }

--- a/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/RepositoryManager.cs
@@ -166,7 +166,11 @@ namespace Tgstation.Server.Host.Components.Repository
 							cloneOptions.FetchOptions.Hydrate(
 								logger,
 								cloneProgressReporter,
-								repositoryFactory.GenerateCredentialsHandler(username, password),
+								await repositoryFactory.GenerateCredentialsHandler(
+									gitRemoteFeaturesFactory.CreateGitRemoteFeatures(url),
+									username,
+									password,
+									cancellationToken),
 								cancellationToken);
 
 							await repositoryFactory.Clone(

--- a/src/Tgstation.Server.Host/Utils/GitHub/GitHubService.cs
+++ b/src/Tgstation.Server.Host/Utils/GitHub/GitHubService.cs
@@ -346,5 +346,9 @@ namespace Tgstation.Server.Host.Utils.GitHub
 					committish)
 				.WaitAsync(cancellationToken);
 		}
+
+		/// <inheritdoc />
+		public string GetGitPassword()
+			=> gitHubClient.Connection.Credentials.Password;
 	}
 }

--- a/src/Tgstation.Server.Host/Utils/GitHub/IAuthenticatedGitHubService.cs
+++ b/src/Tgstation.Server.Host/Utils/GitHub/IAuthenticatedGitHubService.cs
@@ -11,6 +11,12 @@ namespace Tgstation.Server.Host.Utils.GitHub
 	public interface IAuthenticatedGitHubService : IGitHubService
 	{
 		/// <summary>
+		/// Gets the password to use for accessing a given repository.
+		/// </summary>
+		/// <returns>The password to use for accessing a GitHub repository with git.</returns>
+		string GetGitPassword();
+
+		/// <summary>
 		/// Create a comment on a given <paramref name="issueNumber"/>.
 		/// </summary>
 		/// <param name="repoOwner">The owner of the target repository.</param>

--- a/tests/Tgstation.Server.Host.Tests/Components/Repository/TestRepositoryFactory.cs
+++ b/tests/Tgstation.Server.Host.Tests/Components/Repository/TestRepositoryFactory.cs
@@ -1,10 +1,14 @@
-﻿using LibGit2Sharp;
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using LibGit2Sharp;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Moq;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Tgstation.Server.Host.Components.Repository.Tests
 {
@@ -14,7 +18,7 @@ namespace Tgstation.Server.Host.Components.Repository.Tests
 	[TestClass]
 	public sealed class TestRepositoryFactory
 	{
-		static LibGit2RepositoryFactory CreateFactory() => new (Mock.Of<ILogger<LibGit2RepositoryFactory>>());
+		static LibGit2RepositoryFactory CreateFactory() => new(Mock.Of<ILogger<LibGit2RepositoryFactory>>());
 
 		static async Task<LibGit2Sharp.IRepository> TestRepoLoading(
 			string path,
@@ -40,7 +44,7 @@ namespace Tgstation.Server.Host.Components.Repository.Tests
 			{
 				var factory = CreateFactory();
 				var cloneOpts = new CloneOptions();
-				cloneOpts.FetchOptions.CredentialsProvider = factory.GenerateCredentialsHandler(null, null);
+				cloneOpts.FetchOptions.CredentialsProvider = await factory.GenerateCredentialsHandler(Mock.Of<IGitRemoteFeatures>(), null, null, CancellationToken.None);
 				await factory.Clone(
 					new Uri("https://github.com/Cyberboss/Test"),
 					cloneOpts,

--- a/tests/Tgstation.Server.Tests/Live/TestingGitHubService.cs
+++ b/tests/Tgstation.Server.Tests/Live/TestingGitHubService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -23,6 +22,8 @@ namespace Tgstation.Server.Tests.Live
 {
 	sealed class TestingGitHubService : IAuthenticatedGitHubService
 	{
+		static string TestAccessToken => Environment.GetEnvironmentVariable("TGS_TEST_GITHUB_TOKEN");
+
 		static Dictionary<Version, Release> releasesDictionary;
 		static PullRequest testPr;
 		static GitHubCommit testCommit;
@@ -37,7 +38,7 @@ namespace Tgstation.Server.Tests.Live
 			var mockOptions = new Mock<IOptionsMonitor<GeneralConfiguration>>();
 			mockOptions.SetupGet(x => x.CurrentValue).Returns(new GeneralConfiguration
 			{
-				GitHubAccessToken = Environment.GetEnvironmentVariable("TGS_TEST_GITHUB_TOKEN")
+				GitHubAccessToken = TestAccessToken,
 			});
 
 			var gitHubClientFactory = new GitHubClientFactory(new AssemblyInformationProvider(), new BasicHttpMessageHandlerFactory(), mockOptions.Object, Mock.Of<ILogger<GitHubClientFactory>>());
@@ -161,6 +162,12 @@ namespace Tgstation.Server.Tests.Live
 		{
 			logger.LogTrace("GetTgsReleases");
 			return ValueTask.FromResult(releasesDictionary);
+		}
+
+		public string GetGitPassword()
+		{
+			logger.LogTrace("GetGitPassword");
+			return TestAccessToken;
 		}
 	}
 }

--- a/tests/Tgstation.Server.Tests/TestRepository.cs
+++ b/tests/Tgstation.Server.Tests/TestRepository.cs
@@ -18,6 +18,7 @@ using Tgstation.Server.Host.Components.Repository;
 using Tgstation.Server.Host.Configuration;
 using Tgstation.Server.Host.IO;
 using Tgstation.Server.Host.Jobs;
+using Tgstation.Server.Host.Utils.GitHub;
 
 namespace Tgstation.Server.Tests
 {
@@ -81,7 +82,10 @@ namespace Tgstation.Server.Tests
 					tempPath),
 				Mock.Of<IEventConsumer>(),
 				new WindowsPostWriteHandler(),
-				Mock.Of<IGitRemoteFeaturesFactory>(),
+				new GitRemoteFeaturesFactory(
+					Mock.Of<IGitHubServiceFactory>(),
+					Mock.Of<ILoggerFactory>(),
+					Mock.Of<ILogger<GitRemoteFeaturesFactory>>()),
 				Mock.Of<IOptionsMonitor<GeneralConfiguration>>(),
 				Mock.Of<ILogger<Host.Components.Repository.Repository>>(),
 				Mock.Of<ILogger<RepositoryManager>>());


### PR DESCRIPTION
🆑
Fixed issues with performing git operations on private repositories using GitHub App authentication.
Fixed RepoFetch event scripts being called with the TGS internal representation of GitHub private keys instead of a valid access token when app authentication was in use.
/🆑
