### PR TITLE
Convert ActiveTestMerges to a list before iteration

### DIFF
--- a/src/Tgstation.Server.Host/Components/Repository/RepositoryUpdateService.cs
+++ b/src/Tgstation.Server.Host/Components/Repository/RepositoryUpdateService.cs
@@ -221,7 +221,7 @@ namespace Tgstation.Server.Host.Components.Repository
 							testMergeToAdd.MergedAt = DateTimeOffset.UtcNow;
 
 							var activeTestMerges = lastRevisionInfo!.ActiveTestMerges!;
-							foreach (var activeTestMerge in previousRevInfo.ActiveTestMerges!)
+							foreach (var activeTestMerge in previousRevInfo.ActiveTestMerges!.ToList())
 								activeTestMerges.Add(activeTestMerge);
 
 							activeTestMerges.Add(new RevInfoTestMerge(testMergeToAdd, lastRevisionInfo));


### PR DESCRIPTION
🆑
Fixed an edge case that could cause an exception during test merging.
/🆑